### PR TITLE
Identify/include wsgi.py as a "WSGI file"

### DIFF
--- a/touchwsgi.py
+++ b/touchwsgi.py
@@ -10,7 +10,7 @@ class TouchWSGI(sublime_plugin.EventListener):
     Sublime Text 2 Plugin to Touch WSGI Files.
 
     Scans any open folders in the current window when saving a file to see
-    if there is a WSGI file in it.
+    if there is a WSGI file in it. "WSGI file" == *.wsgi or *wsgi.py
 
     Now also scans subfolders.
     """
@@ -24,6 +24,8 @@ class TouchWSGI(sublime_plugin.EventListener):
 
     def check_folder(self, path):
         wsgi_files = filter(os.path.isfile, glob(path + "/*.wsgi"))
+        if len(wsgi_files) == 0:
+            wsgi_files = filter(os.path.isfile, glob(path + "/*wsgi.py"))
         if len(wsgi_files) > 0:
             print "Found WSGI File(s) in " + path
             for wsgi_file in wsgi_files:


### PR DESCRIPTION
Some devs prefer wsgi files having .py extension, i.e. wsgi.py. Include same in searches.
