### PR TITLE
Removed unnecessary recursion

### DIFF
--- a/touchwsgi.py
+++ b/touchwsgi.py
@@ -13,23 +13,17 @@ class TouchWSGI(sublime_plugin.EventListener):
     if there is a WSGI file in it. "WSGI file" == r"^.*[\.]wsgi(\.py)?$"
     """
     def on_post_save_async(self, view):
-        window = view.window()
-        for folder in window.folders():
-            self.get_folders(folder)
-
-    def check_files(self, path, files):
-        regex = re.compile(r"^.*[\.]wsgi(\.py)?$")
-        files = [filename for filename in files if regex.match(filename) is not None]
-
-        if len(files) > 0:
-            for filename in files:
-                os.utime(path + '/' + filename, None)
+        #start_time = time.time()
+        for folder in view.window().folders():
+            # only check when saved file in project
+            if view.file_name().startswith(folder):
+                self.get_folders(folder)
+        #print("* All checked")
+        #print("--- %s seconds ---" % (time.time() - start_time))
 
     def get_folders(self, path):
+        regex = re.compile(r"^.*\.wsgi(\.py)?$")
         for root, dirnames, filenames in os.walk(path):
-            if len(dirnames) > 0:
-                for dirname in dirnames:
-                    self.check_files(root, filenames)
-                    filenames = []
-                    new_path = os.path.join(root, dirname)
-                    self.get_folders(new_path)
+            for file in filenames:
+                if regex.match(file):
+                    os.utime(os.path.join(root, file), None)


### PR DESCRIPTION
os.walk already walks the entire directory tree. Recursion only created an infinite loop. Also it is not necessary to touch wsgi files if saved file was not in project folder.